### PR TITLE
Return a Result instead of panicking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ repository = "https://github.com/Kimundi/rustc-version-rs"
 keywords = ["version", "rustc"]
 
 [dependencies]
-semver = "0.1"
+semver = "0.2.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,10 +24,10 @@
 //!
 //! fn main() {
 //!     // Assert we haven't travelled back in time
-//!     assert!(version().major >= 1);
+//!     assert!(version().unwrap().major >= 1);
 //!
 //!     // Set cfg flags depending on release channel
-//!     match version_meta().channel {
+//!     match version_meta().unwrap().channel {
 //!         Channel::Stable => {
 //!             println!("cargo:rustc-cfg=RUSTC_IS_STABLE");
 //!         }
@@ -43,7 +43,7 @@
 //!     }
 //!
 //!     // Directly check a semver version requirment
-//!     if version_matches(">= 1.4.0") {
+//!     if version_matches(">= 1.4.0").unwrap() {
 //!         println!("cargo:rustc-cfg=compiler_has_important_bugfix");
 //!     }
 //! }
@@ -52,8 +52,85 @@
 extern crate semver;
 use semver::{Version, VersionReq, Identifier};
 use std::process::Command;
-use std::env;
+use std::{env, error, fmt, io, str};
 use std::ffi::OsString;
+
+/// The error type for this crate.
+#[derive(Debug)]
+pub enum Error {
+    /// An error ocurrend when executing the `rustc` command.
+    CouldNotExecuteCommand(io::Error),
+    /// The output of `rustc -vV` was not valid utf-8.
+    Utf8Error(str::Utf8Error),
+    /// The output of `rustc -vV` was not in the expected format.
+    UnexpectedVersionFormat,
+    /// An error ocurred in parsing a `VersionReq`.
+    ReqParseError(semver::ReqParseError),
+    /// An error ocurred in parsing the semver.
+    SemVerError(semver::SemVerError),
+    /// The pre-release tag is unknown.
+    UnknownPreReleaseTag(Identifier),
+}
+use Error::*;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use std::error::Error;
+        match *self {
+            CouldNotExecuteCommand(ref e) => write!(f, "{}: {}", self.description(), e),
+            Utf8Error(_) => write!(f, "{}", self.description()),
+            UnexpectedVersionFormat => write!(f, "{}", self.description()),
+            ReqParseError(ref e) => write!(f, "{}: {}", self.description(), e),
+            SemVerError(ref e) => write!(f, "{}: {}", self.description(), e),
+            UnknownPreReleaseTag(ref i) => write!(f, "{}: {}", self.description(), i),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            CouldNotExecuteCommand(ref e) => Some(e),
+            Utf8Error(ref e) => Some(e),
+            UnexpectedVersionFormat => None,
+            ReqParseError(ref e) => Some(e),
+            SemVerError(ref e) => Some(e),
+            UnknownPreReleaseTag(_) => None,
+        }
+    }
+
+    fn description(&self) -> &str {
+        match *self {
+            CouldNotExecuteCommand(_) => "could not execute command",
+            Utf8Error(_) => "invalid UTF-8 output from `rustc -vV`",
+            UnexpectedVersionFormat => "unexpected `rustc -vV` format",
+            ReqParseError(_) => "error parsing version requirement",
+            SemVerError(_) => "error parsing version",
+            UnknownPreReleaseTag(_) => "unknown pre-release tag",
+        }
+    }
+}
+
+macro_rules! impl_from {
+    ($($err_ty:ty => $variant:ident),* $(,)*) => {
+        $(
+            impl From<$err_ty> for Error {
+                fn from(e: $err_ty) -> Error {
+                    Error::$variant(e)
+                }
+            }
+        )*
+    }
+}
+
+impl_from! {
+    str::Utf8Error => Utf8Error,
+    semver::SemVerError => SemVerError,
+    semver::ReqParseError => ReqParseError,
+}
+
+/// The result type for this crate.
+pub type Result<T> = std::result::Result<T, Error>;
 
 /// Release channel of the compiler.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -69,7 +146,7 @@ pub enum Channel {
 }
 
 /// Rustc version plus metada like git short hash and build date.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct VersionMeta {
     /// Version of the compiler
     pub semver: Version,
@@ -94,50 +171,50 @@ pub struct VersionMeta {
 }
 
 /// Returns the `rustc` SemVer version.
-pub fn version() -> Version {
-    version_meta().semver
+pub fn version() -> Result<Version> {
+    Ok(try!(version_meta()).semver)
 }
 
 /// Returns the `rustc` SemVer version and additional metadata
 /// like the git short hash and build date.
-pub fn version_meta() -> VersionMeta {
+pub fn version_meta() -> Result<VersionMeta> {
     let cmd = env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
 
-    let out = Command::new(&cmd)
-        .arg("-vV")
-        .output()
-        .unwrap_or_else(|e| { panic!("failed to execute `RUSTC -vV`: {}", e) });
+    let out = match Command::new(&cmd).arg("-vV").output() {
+        Err(e) => return Err(CouldNotExecuteCommand(e)),
+        Ok(out) => out,
+    };
 
-    let out = String::from_utf8(out.stdout)
-        .ok()
-        .expect("non utf8 output from RUSTC -vV");
+    let out = try!(str::from_utf8(&out.stdout));
 
-    version_meta_for(&out)
+    version_meta_for(out)
 }
 
 /// Parses a "rustc -vV" output string and returns
 /// the SemVer version and additional metadata
 /// like the git short hash and build date.
-pub fn version_meta_for(verbose_version_string: &str) -> VersionMeta {
+pub fn version_meta_for(verbose_version_string: &str) -> Result<VersionMeta> {
     let out: Vec<_> = verbose_version_string.lines().collect();
 
-    const ERR_MSG: &'static str = "unexpected -vV format";
-
-    assert!(out.len() == 6 || out.len() == 7, ERR_MSG);
+    if !(out.len() == 6 || out.len() == 7) {
+        return Err(UnexpectedVersionFormat);
+    }
 
     let short_version_string = out[0];
 
-    fn expect_prefix<'a>(line: &'a str, prefix: &str) -> &'a str {
-        assert!(line.starts_with(prefix), ERR_MSG);
-        &line[prefix.len()..]
+    fn expect_prefix<'a>(line: &'a str, prefix: &str) -> Result<&'a str> {
+        match line.starts_with(prefix) {
+            true => Ok(&line[prefix.len()..]),
+            false => Err(UnexpectedVersionFormat),
+        }
     }
 
-    let commit_hash = match expect_prefix(out[2], "commit-hash: ") {
+    let commit_hash = match try!(expect_prefix(out[2], "commit-hash: ")) {
         "unknown" => None,
         hash => Some(hash.to_owned()),
     };
 
-    let commit_date = match expect_prefix(out[3], "commit-date: ") {
+    let commit_date = match try!(expect_prefix(out[3], "commit-date: ")) {
         "unknown" => None,
         hash => Some(hash.to_owned()),
     };
@@ -146,7 +223,7 @@ pub fn version_meta_for(verbose_version_string: &str) -> VersionMeta {
     let mut idx = 4;
     let mut build_date = None;
     if out[idx].starts_with("build-date") {
-        build_date = match expect_prefix(out[idx], "build-date: ") {
+        build_date = match try!(expect_prefix(out[idx], "build-date: ")) {
             "unknown" => None,
             s => Some(s.to_owned()),
         };
@@ -154,11 +231,11 @@ pub fn version_meta_for(verbose_version_string: &str) -> VersionMeta {
     }
 
 
-    let host = expect_prefix(out[idx], "host: ");
+    let host = try!(expect_prefix(out[idx], "host: "));
     idx = idx + 1;
-    let release = expect_prefix(out[idx], "release: ");
+    let release = try!(expect_prefix(out[idx], "release: "));
 
-    let semver = Version::parse(release).unwrap();
+    let semver: Version = try!(release.parse());
 
     let channel = if semver.pre.is_empty() {
         Channel::Stable
@@ -170,11 +247,11 @@ pub fn version_meta_for(verbose_version_string: &str) -> VersionMeta {
                 if s == "beta" => Channel::Beta,
             Identifier::AlphaNumeric(ref s)
                 if s == "nightly" => Channel::Nightly,
-            ref x => panic!("Unknown pre-release tag {}", x),
+            ref x => return Err(UnknownPreReleaseTag(x.clone())),
         }
     };
 
-    VersionMeta {
+    Ok(VersionMeta {
         semver: semver,
         commit_hash: commit_hash,
         commit_date: commit_date,
@@ -182,31 +259,30 @@ pub fn version_meta_for(verbose_version_string: &str) -> VersionMeta {
         channel: channel,
         host: host.into(),
         short_version_string: short_version_string.into(),
-    }
+    })
 }
 
 /// Check wether the `rustc` version matches the given SemVer
 /// version requirement.
-pub fn version_matches(req: &str) -> bool {
-    VersionReq::parse(req).unwrap().matches(&version())
+pub fn version_matches(req: &str) -> Result<bool> {
+    let req: VersionReq = try!(req.parse());
+    Ok(req.matches(&try!(version())))
 }
 
 #[test]
 fn smoketest() {
-    let v = version();
+    let v = version().unwrap();
     assert!(v.major >= 1);
 
-    let v = version_meta();
+    let v = version_meta().unwrap();
     assert!(v.semver.major >= 1);
 
-    assert!(version_matches(">= 1.0.0"));
+    assert!(version_matches(">= 1.0.0").unwrap());
 }
 
 #[test]
-#[should_panic(expected = "unexpected")]
-// Characterization test for behavior on an unexpected key.
 fn parse_unexpected() {
-    version_meta_for(
+    let res = version_meta_for(
 "rustc 1.0.0 (a59de37e9 2015-05-13) (built 2015-05-14)
 binary: rustc
 commit-hash: a59de37e99060162a2674e3ff45409ac73595c0e
@@ -214,6 +290,12 @@ commit-date: 2015-05-13
 rust-birthday: 2015-05-14
 host: x86_64-unknown-linux-gnu
 release: 1.0.0");
+
+    assert!(match res {
+        Err(UnexpectedVersionFormat) => true,
+        _ => false,
+    });
+
 }
 
 #[test]
@@ -225,7 +307,7 @@ commit-hash: a59de37e99060162a2674e3ff45409ac73595c0e
 commit-date: 2015-05-13
 build-date: 2015-05-14
 host: x86_64-unknown-linux-gnu
-release: 1.0.0");
+release: 1.0.0").unwrap();
 
     assert_eq!(version.semver, Version::parse("1.0.0").unwrap());
     assert_eq!(version.commit_hash, Some("a59de37e99060162a2674e3ff45409ac73595c0e".into()));
@@ -245,7 +327,7 @@ binary: rustc
 commit-hash: unknown
 commit-date: unknown
 host: x86_64-unknown-linux-gnu
-release: 1.3.0");
+release: 1.3.0").unwrap();
 
     assert_eq!(version.semver, Version::parse("1.3.0").unwrap());
     assert_eq!(version.commit_hash, None);
@@ -263,7 +345,7 @@ binary: rustc
 commit-hash: 65d5c083377645a115c4ac23a620d3581b9562b6
 commit-date: 2015-09-29
 host: x86_64-unknown-linux-gnu
-release: 1.5.0-nightly");
+release: 1.5.0-nightly").unwrap();
 
     assert_eq!(version.semver, Version::parse("1.5.0-nightly").unwrap());
     assert_eq!(version.commit_hash, Some("65d5c083377645a115c4ac23a620d3581b9562b6".into()));
@@ -281,7 +363,7 @@ binary: rustc
 commit-hash: 9a92aaf19a64603b02b4130fe52958cc12488900
 commit-date: 2015-09-15
 host: x86_64-unknown-linux-gnu
-release: 1.3.0");
+release: 1.3.0").unwrap();
 
     assert_eq!(version.semver, Version::parse("1.3.0").unwrap());
     assert_eq!(version.commit_hash, Some("9a92aaf19a64603b02b4130fe52958cc12488900".into()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ pub fn version_meta_for(verbose_version_string: &str) -> VersionMeta {
 
 
     let host = expect_prefix(out[idx], "host: ");
-    idx = idx +1;
+    idx = idx + 1;
     let release = expect_prefix(out[idx], "release: ");
 
     let semver = Version::parse(release).unwrap();


### PR DESCRIPTION
This gives the choice of how to handle the error to the downstream user,
making it easier to use rustc_version as a library in non-build-script
contexts.

This is a breaking change.
