### PR TITLE
Bump semver to 0.2, remove version_matches()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ repository = "https://github.com/Kimundi/rustc-version-rs"
 keywords = ["version", "rustc"]
 
 [dependencies]
-semver = "0.1"
+semver = "0.2"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ git = "https://github.com/Kimundi/rustc-version-rs"
 // This could be a cargo build script
 
 extern crate rustc_version;
-use rustc_version::{version, version_matches, version_meta, Channel};
+use rustc_version::{version, version_meta, Channel, Version};
 
 fn main() {
     // Assert we haven't travelled back in time
@@ -52,8 +52,8 @@ fn main() {
         }
     }
 
-    // Directly check a semver version requirment
-    if version_matches(">= 1.4.0") {
+    // Check for a minimum version
+    if version() >= Version::parse("1.4.0").unwrap() {
         println!("cargo:rustc-cfg=compiler_has_important_bugfix");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! // This could be a cargo build script
 //!
 //! extern crate rustc_version;
-//! use rustc_version::{version, version_matches, version_meta, Channel};
+//! use rustc_version::{version, version_meta, Channel, Version};
 //!
 //! fn main() {
 //!     // Assert we haven't travelled back in time
@@ -42,18 +42,22 @@
 //!         }
 //!     }
 //!
-//!     // Directly check a semver version requirment
-//!     if version_matches(">= 1.4.0") {
+//!     // Check for a minimum version
+//!     if version() >= Version::parse("1.4.0").unwrap() {
 //!         println!("cargo:rustc-cfg=compiler_has_important_bugfix");
 //!     }
 //! }
 //! ```
 
 extern crate semver;
-use semver::{Version, VersionReq, Identifier};
+use semver::Identifier;
 use std::process::Command;
 use std::env;
 use std::ffi::OsString;
+
+// Convenience re-export to allow version comparison without needing to add
+// semver crate.
+pub use semver::Version;
 
 /// Release channel of the compiler.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -185,12 +189,6 @@ pub fn version_meta_for(verbose_version_string: &str) -> VersionMeta {
     }
 }
 
-/// Check wether the `rustc` version matches the given SemVer
-/// version requirement.
-pub fn version_matches(req: &str) -> bool {
-    VersionReq::parse(req).unwrap().matches(&version())
-}
-
 #[test]
 fn smoketest() {
     let v = version();
@@ -199,7 +197,7 @@ fn smoketest() {
     let v = version_meta();
     assert!(v.semver.major >= 1);
 
-    assert!(version_matches(">= 1.0.0"));
+    assert!(version() >= Version::parse("1.0.0").unwrap());
 }
 
 #[test]


### PR DESCRIPTION
semver 0.2 was the first to include a fix to how `VersionReq`
comparisons work with pre-release identifiers. The fix results in, eg,

```
version_matches(">= 1.4.0")
```

not matching for a compiler version `1.8.0-nightly`. For more details,
see https://github.com/steveklabnik/semver/pull/54.

This makes `version_matches()` far less useful, and so it is removed.
It's still possible to get the original intent by using the `Ord` impl
on `semver::Version`. To make this more convenient, `semver::Version` is
exported from this crate.

This is a breaking change.
