### PR TITLE
Use standard form for dual-licensing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustc_version"
 version = "0.2.0"
 authors = ["Marvin Löbel <loebel.marvin@gmail.com>"]
-license = "MIT OR Apache-2.0"
+license = "MIT/Apache-2.0"
 
 description = "A library for querying the version of a installed rustc compiler"
 readme = "README.md"


### PR DESCRIPTION
[As documented](http://doc.crates.io/manifest.html), the standard form for dual-licensing is with a slash: 

> Multiple licenses can be separated with a `/`.

This helps out tools like `cargo license` correctly group libraries ^_^