### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ At the point of the last update of this README, the latest published version cou
 Add the following dependency to your Cargo manifest...
 
 ```toml
-[dependencies]
+[build-dependencies]
 rustc_version = "0.2"
 ```
 


### PR DESCRIPTION
The README instructs the user to add `rust_c` to the dependencies section, while the following example requires it to be in the build-dependencies section. Since it seems build scripts are the primary use-case for this script, we can reduce friction with this change (it caused me about 5 minutes worth of research).