### PR TITLE
Use docs.rs documentation link for crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 
 description = "A library for querying the version of a installed rustc compiler"
 readme = "README.md"
-documentation = "http://kimundi.github.io/rustc-version-rs/rustc_version/index.html"
+documentation = "https://docs.rs/rustc_version/"
 
 repository = "https://github.com/Kimundi/rustc-version-rs"
 keywords = ["version", "rustc"]


### PR DESCRIPTION
Not sure if there is a specific reason to link to the github pages docs, so feel free to close this PR.

The main benefit of docs.rs is that you can switch between different versions of
the crate at the top: https://docs.rs/rustc_version/