### PR TITLE
Parse llvm version

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,62 @@
 use semver::{self, Identifier};
-use std::{self, error, fmt, io, str};
+use std::{self, error, fmt, io, num, str};
+
+/// LLVM Version Parse Error
+#[derive(Debug)]
+pub enum LlvmVersionParseError {
+    /// An error occurred in parsing a version component as an integer
+    ParseIntError(num::ParseIntError),
+    /// A version component must not have leading zeros
+    ComponentMustNotHaveLeadingZeros,
+    /// A version component has a sign
+    ComponentMustNotHaveSign,
+    /// Minor version component must be zero on LLVM versions later than 4.0
+    MinorVersionMustBeZeroAfter4,
+    /// Minor version component is required on LLVM versions earlier than 4.0
+    MinorVersionRequiredBefore4,
+    /// Too many components
+    TooManyComponents,
+}
+
+impl From<num::ParseIntError> for LlvmVersionParseError {
+    fn from(e: num::ParseIntError) -> Self {
+        Self::ParseIntError(e)
+    }
+}
+
+impl fmt::Display for LlvmVersionParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ParseIntError(e) => write!(f, "error parsing LLVM version component: {}", e),
+            Self::ComponentMustNotHaveLeadingZeros => {
+                write!(f, "a version component must not have leading zeros")
+            }
+            Self::ComponentMustNotHaveSign => write!(f, "a version component must not have a sign"),
+            Self::MinorVersionMustBeZeroAfter4 => write!(
+                f,
+                "LLVM's minor version component must be 0 for versions greater than 4.0"
+            ),
+            Self::MinorVersionRequiredBefore4 => write!(
+                f,
+                "LLVM's minor version component is required for versions less than 4.0"
+            ),
+            Self::TooManyComponents => write!(f, "too many version components"),
+        }
+    }
+}
+
+impl error::Error for LlvmVersionParseError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Self::ParseIntError(e) => Some(e),
+            Self::ComponentMustNotHaveLeadingZeros
+            | Self::ComponentMustNotHaveSign
+            | Self::MinorVersionMustBeZeroAfter4
+            | Self::MinorVersionRequiredBefore4
+            | Self::TooManyComponents => None,
+        }
+    }
+}
 
 /// The error type for this crate.
 #[derive(Debug)]
@@ -16,6 +73,8 @@ pub enum Error {
     SemVerError(semver::SemVerError),
     /// The pre-release tag is unknown.
     UnknownPreReleaseTag(Identifier),
+    /// An error occurred in parsing a `LlvmVersion`.
+    LlvmVersionError(LlvmVersionParseError),
 }
 use Error::*;
 
@@ -28,6 +87,7 @@ impl fmt::Display for Error {
             ReqParseError(ref e) => write!(f, "error parsing version requirement: {}", e),
             SemVerError(ref e) => write!(f, "error parsing version: {}", e),
             UnknownPreReleaseTag(ref i) => write!(f, "unknown pre-release tag: {}", i),
+            LlvmVersionError(ref e) => write!(f, "error parsing LLVM's version: {}", e),
         }
     }
 }
@@ -41,6 +101,7 @@ impl error::Error for Error {
             ReqParseError(ref e) => Some(e),
             SemVerError(ref e) => Some(e),
             UnknownPreReleaseTag(_) => None,
+            LlvmVersionError(ref e) => Some(e),
         }
     }
 }
@@ -61,7 +122,8 @@ impl_from! {
     str::Utf8Error => Utf8Error,
     semver::SemVerError => SemVerError,
     semver::ReqParseError => ReqParseError,
+    LlvmVersionParseError => LlvmVersionError,
 }
 
 /// The result type for this crate.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
-use std::{self, error, fmt, io, str};
 use semver::{self, Identifier};
+use std::{self, error, fmt, io, str};
 
 /// The error type for this crate.
 #[derive(Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,15 +4,15 @@ use std::{self, error, fmt, io, str};
 /// The error type for this crate.
 #[derive(Debug)]
 pub enum Error {
-    /// An error ocurrend when executing the `rustc` command.
+    /// An error occurred when executing the `rustc` command.
     CouldNotExecuteCommand(io::Error),
     /// The output of `rustc -vV` was not valid utf-8.
     Utf8Error(str::Utf8Error),
     /// The output of `rustc -vV` was not in the expected format.
     UnexpectedVersionFormat,
-    /// An error ocurred in parsing a `VersionReq`.
+    /// An error occurred in parsing a `VersionReq`.
     ReqParseError(semver::ReqParseError),
-    /// An error ocurred in parsing the semver.
+    /// An error occurred in parsing the semver.
     SemVerError(semver::SemVerError),
     /// The pre-release tag is unknown.
     UnknownPreReleaseTag(Identifier),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ impl FromStr for LlvmVersion {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut parts = s
-            .splitn(3, '.')
+            .split('.')
             .map(|part| -> Result<u64, LlvmVersionParseError> {
                 match part.as_bytes() {
                     // check for at least 2 characters to avoid erroring on "0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,11 +114,14 @@ impl FromStr for LlvmVersion {
         let mut parts = s
             .split('.')
             .map(|part| -> Result<u64, LlvmVersionParseError> {
-                match part.as_bytes() {
-                    // check for at least 2 characters to avoid erroring on "0"
-                    [b'0', _, ..] => Err(LlvmVersionParseError::ComponentMustNotHaveLeadingZeros),
-                    [b'-', ..] | [b'+', ..] => Err(LlvmVersionParseError::ComponentMustNotHaveSign),
-                    _ => Ok(part.parse()?),
+                if part == "0" {
+                    Ok(0)
+                } else if part.starts_with('0') {
+                    Err(LlvmVersionParseError::ComponentMustNotHaveLeadingZeros)
+                } else if part.starts_with('-') || part.starts_with('+') {
+                    Err(LlvmVersionParseError::ComponentMustNotHaveSign)
+                } else {
+                    Ok(part.parse()?)
                 }
             });
         let major = parts.next().unwrap()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub enum Channel {
 
 /// LLVM version
 ///
-/// LLVM's version numbering scheme is not semvar compatible until version 4.0
+/// LLVM's version numbering scheme is not semver compatible until version 4.0
 ///
 /// rustc [just prints the major and minor versions], so other parts of the version are not included.
 ///
@@ -107,7 +107,7 @@ impl fmt::Display for LLVMVersion {
     }
 }
 
-/// Rustc version plus metada like git short hash and build date.
+/// Rustc version plus metadata like git short hash and build date.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct VersionMeta {
     /// Version of the compiler

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -592,6 +592,12 @@ LLVM version: 5.6",
     });
 }
 
+#[test]
+fn test_llvm_version_comparison() {
+    // check that field order is correct
+    assert!(LLVMVersion { major: 3, minor: 9 } < LLVMVersion { major: 4, minor: 0 });
+}
+
 /*
 #[test]
 fn version_matches_replacement() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,9 +61,9 @@ doctest!("../README.md");
 
 extern crate semver;
 use semver::Identifier;
+use std::ffi::OsString;
 use std::process::Command;
 use std::{env, str};
-use std::ffi::OsString;
 
 // Convenience re-export to allow version comparison without needing to add
 // semver crate.
@@ -115,7 +115,10 @@ impl VersionMeta {
     pub fn for_command(cmd: Command) -> Result<VersionMeta> {
         let mut cmd = cmd;
 
-        let out = cmd.arg("-vV").output().map_err(Error::CouldNotExecuteCommand)?;
+        let out = cmd
+            .arg("-vV")
+            .output()
+            .map_err(Error::CouldNotExecuteCommand)?;
         let out = str::from_utf8(&out.stdout)?;
 
         version_meta_for(out)
@@ -218,51 +221,60 @@ fn smoketest() {
 #[test]
 fn parse_unexpected() {
     let res = version_meta_for(
-"rustc 1.0.0 (a59de37e9 2015-05-13) (built 2015-05-14)
+        "rustc 1.0.0 (a59de37e9 2015-05-13) (built 2015-05-14)
 binary: rustc
 commit-hash: a59de37e99060162a2674e3ff45409ac73595c0e
 commit-date: 2015-05-13
 rust-birthday: 2015-05-14
 host: x86_64-unknown-linux-gnu
-release: 1.0.0");
+release: 1.0.0",
+    );
 
     assert!(match res {
         Err(Error::UnexpectedVersionFormat) => true,
         _ => false,
     });
-
 }
 
 #[test]
 fn parse_1_0_0() {
     let version = version_meta_for(
-"rustc 1.0.0 (a59de37e9 2015-05-13) (built 2015-05-14)
+        "rustc 1.0.0 (a59de37e9 2015-05-13) (built 2015-05-14)
 binary: rustc
 commit-hash: a59de37e99060162a2674e3ff45409ac73595c0e
 commit-date: 2015-05-13
 build-date: 2015-05-14
 host: x86_64-unknown-linux-gnu
-release: 1.0.0").unwrap();
+release: 1.0.0",
+    )
+    .unwrap();
 
     assert_eq!(version.semver, Version::parse("1.0.0").unwrap());
-    assert_eq!(version.commit_hash, Some("a59de37e99060162a2674e3ff45409ac73595c0e".into()));
+    assert_eq!(
+        version.commit_hash,
+        Some("a59de37e99060162a2674e3ff45409ac73595c0e".into())
+    );
     assert_eq!(version.commit_date, Some("2015-05-13".into()));
     assert_eq!(version.build_date, Some("2015-05-14".into()));
     assert_eq!(version.channel, Channel::Stable);
     assert_eq!(version.host, "x86_64-unknown-linux-gnu");
-    assert_eq!(version.short_version_string, "rustc 1.0.0 (a59de37e9 2015-05-13) (built 2015-05-14)");
+    assert_eq!(
+        version.short_version_string,
+        "rustc 1.0.0 (a59de37e9 2015-05-13) (built 2015-05-14)"
+    );
 }
-
 
 #[test]
 fn parse_unknown() {
     let version = version_meta_for(
-"rustc 1.3.0
+        "rustc 1.3.0
 binary: rustc
 commit-hash: unknown
 commit-date: unknown
 host: x86_64-unknown-linux-gnu
-release: 1.3.0").unwrap();
+release: 1.3.0",
+    )
+    .unwrap();
 
     assert_eq!(version.semver, Version::parse("1.3.0").unwrap());
     assert_eq!(version.commit_hash, None);
@@ -275,56 +287,80 @@ release: 1.3.0").unwrap();
 #[test]
 fn parse_nightly() {
     let version = version_meta_for(
-"rustc 1.5.0-nightly (65d5c0833 2015-09-29)
+        "rustc 1.5.0-nightly (65d5c0833 2015-09-29)
 binary: rustc
 commit-hash: 65d5c083377645a115c4ac23a620d3581b9562b6
 commit-date: 2015-09-29
 host: x86_64-unknown-linux-gnu
-release: 1.5.0-nightly").unwrap();
+release: 1.5.0-nightly",
+    )
+    .unwrap();
 
     assert_eq!(version.semver, Version::parse("1.5.0-nightly").unwrap());
-    assert_eq!(version.commit_hash, Some("65d5c083377645a115c4ac23a620d3581b9562b6".into()));
+    assert_eq!(
+        version.commit_hash,
+        Some("65d5c083377645a115c4ac23a620d3581b9562b6".into())
+    );
     assert_eq!(version.commit_date, Some("2015-09-29".into()));
     assert_eq!(version.channel, Channel::Nightly);
     assert_eq!(version.host, "x86_64-unknown-linux-gnu");
-    assert_eq!(version.short_version_string, "rustc 1.5.0-nightly (65d5c0833 2015-09-29)");
+    assert_eq!(
+        version.short_version_string,
+        "rustc 1.5.0-nightly (65d5c0833 2015-09-29)"
+    );
 }
 
 #[test]
 fn parse_stable() {
     let version = version_meta_for(
-"rustc 1.3.0 (9a92aaf19 2015-09-15)
+        "rustc 1.3.0 (9a92aaf19 2015-09-15)
 binary: rustc
 commit-hash: 9a92aaf19a64603b02b4130fe52958cc12488900
 commit-date: 2015-09-15
 host: x86_64-unknown-linux-gnu
-release: 1.3.0").unwrap();
+release: 1.3.0",
+    )
+    .unwrap();
 
     assert_eq!(version.semver, Version::parse("1.3.0").unwrap());
-    assert_eq!(version.commit_hash, Some("9a92aaf19a64603b02b4130fe52958cc12488900".into()));
+    assert_eq!(
+        version.commit_hash,
+        Some("9a92aaf19a64603b02b4130fe52958cc12488900".into())
+    );
     assert_eq!(version.commit_date, Some("2015-09-15".into()));
     assert_eq!(version.channel, Channel::Stable);
     assert_eq!(version.host, "x86_64-unknown-linux-gnu");
-    assert_eq!(version.short_version_string, "rustc 1.3.0 (9a92aaf19 2015-09-15)");
+    assert_eq!(
+        version.short_version_string,
+        "rustc 1.3.0 (9a92aaf19 2015-09-15)"
+    );
 }
 
 #[test]
 fn parse_1_16_0_nightly() {
     let version = version_meta_for(
-"rustc 1.16.0-nightly (5d994d8b7 2017-01-05)
+        "rustc 1.16.0-nightly (5d994d8b7 2017-01-05)
 binary: rustc
 commit-hash: 5d994d8b7e482e87467d4a521911477bd8284ce3
 commit-date: 2017-01-05
 host: x86_64-unknown-linux-gnu
 release: 1.16.0-nightly
-LLVM version: 3.9").unwrap();
+LLVM version: 3.9",
+    )
+    .unwrap();
 
     assert_eq!(version.semver, Version::parse("1.16.0-nightly").unwrap());
-    assert_eq!(version.commit_hash, Some("5d994d8b7e482e87467d4a521911477bd8284ce3".into()));
+    assert_eq!(
+        version.commit_hash,
+        Some("5d994d8b7e482e87467d4a521911477bd8284ce3".into())
+    );
     assert_eq!(version.commit_date, Some("2017-01-05".into()));
     assert_eq!(version.channel, Channel::Nightly);
     assert_eq!(version.host, "x86_64-unknown-linux-gnu");
-    assert_eq!(version.short_version_string, "rustc 1.16.0-nightly (5d994d8b7 2017-01-05)");
+    assert_eq!(
+        version.short_version_string,
+        "rustc 1.16.0-nightly (5d994d8b7 2017-01-05)"
+    );
 }
 
 /*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -569,8 +569,18 @@ fn parse_llvm_version_leading_zero_on_nonzero() {
 }
 
 #[test]
-fn parse_llvm_version_too_many_components() {
+fn parse_llvm_version_3_components() {
     let res: Result<LlvmVersion, _> = "4.0.0".parse();
+
+    assert!(match res {
+        Err(LlvmVersionParseError::TooManyComponents) => true,
+        _ => false,
+    });
+}
+
+#[test]
+fn parse_llvm_version_4_components() {
+    let res: Result<LlvmVersion, _> = "4.0.0.0".parse();
 
     assert!(match res {
         Err(LlvmVersionParseError::TooManyComponents) => true,


### PR DESCRIPTION
Parse LLVM version too

Fixes #30

If you like, I can add a separate method to parse the LLVM version string and/or produce more specific errors on parse failure.