### PR TITLE
respect RUSTUP_TOOLCHAIN env var

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,13 +199,17 @@ pub fn version() -> Result<Version> {
 /// like the git short hash and build date.
 pub fn version_meta() -> Result<VersionMeta> {
     let rustc = env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
-    let cmd = if let Some(wrapper) = env::var_os("RUSTC_WRAPPER").filter(|w| !w.is_empty()) {
+    let mut cmd = if let Some(wrapper) = env::var_os("RUSTC_WRAPPER").filter(|w| !w.is_empty()) {
         let mut cmd = Command::new(wrapper);
         cmd.arg(rustc);
         cmd
     } else {
         Command::new(rustc)
     };
+
+    if let Some(toolchain) = env::var_os("RUSTUP_TOOLCHAIN") {
+        cmd.env("RUSTUP_TOOLCHAIN", toolchain);
+    }
 
     VersionMeta::for_command(cmd)
 }


### PR DESCRIPTION
See https://rust-lang.github.io/rustup/environment-variables.html

This enables `+toolchain` handling. See for example: 
```shell
λ rustc -vV
rustc 1.80.1 (3f5fd8dd4 2024-08-06)
binary: rustc
commit-hash: 3f5fd8dd41153bc5fdca9427e9e05be2c767ba23
commit-date: 2024-08-06
host: x86_64-unknown-linux-gnu
release: 1.80.1
LLVM version: 18.1.7

λ RUSTUP_TOOLCHAIN=nightly rustc -vV
rustc 1.82.0-nightly (13a52890d 2024-08-14)
binary: rustc
commit-hash: 13a52890dde8cfeb95069d77c223ac37c0cf3a46
commit-date: 2024-08-14
host: x86_64-unknown-linux-gnu
release: 1.82.0-nightly
LLVM version: 19.1.0

```
