### PR TITLE
bump version number: v0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Dirkjan Ochtman <dirkjan@ochtman.nl>", "Marvin Löbel <loebel.marvin@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A library for querying the version of a installed rustc compiler"


### PR DESCRIPTION
@djc [wrote](https://github.com/djc/rustc-version-rs/pull/46#issuecomment-2069317180)

> Thanks! If you want a release for this, could you submit a PR to bump the version number?

Here you go. :)